### PR TITLE
Handle blank tag names in profile tags

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -12,8 +12,10 @@ class ProfilesController < ApplicationController
   end
 
   def add_tag
-    tag_name = params[:tag_name].strip.downcase
+    tag_name = params[:tag_name].to_s.strip.downcase
     tag_type = params[:tag_type]
+
+    return redirect_to(profile_path, alert: 'Tag name cannot be blank.') if tag_name.blank?
 
     if tag_type == 'location'
       tag = LocationTag.find_or_create_by(location: tag_name)

--- a/spec/controllers/profiles_controller_spec.rb
+++ b/spec/controllers/profiles_controller_spec.rb
@@ -76,6 +76,13 @@ RSpec.describe ProfilesController, type: :controller do
       end
     end
 
+    context "without tag_name" do
+      it "redirects to the profile page" do
+        post :add_tag, params: { tag_type: "location" }
+        expect(response).to redirect_to(profile_path)
+      end
+    end
+
     it "redirects to the profile page" do
       post :add_tag, params: { tag_name: "some tag", tag_type: "location" }
       expect(response).to redirect_to(profile_path)


### PR DESCRIPTION
## Summary
- Sanitize tag_name input in ProfilesController#add_tag and block blank tags with alert
- Test add_tag without tag_name to ensure redirect without error

## Testing
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_b_68b5d2d10cec833084841ceceee3022b