### PR TITLE
Add review system for offerings

### DIFF
--- a/app/controllers/offerings_controller.rb
+++ b/app/controllers/offerings_controller.rb
@@ -8,6 +8,9 @@ class OfferingsController < ApplicationController
   end
 
   def show
+    @reviews = @offering.reviews.includes(:user)
+    @review = Review.new
+    @can_review = @offering.bookings.where(user: current_user, status: :completed).exists?
   end
 
   def new

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -1,0 +1,45 @@
+class ReviewsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_offering
+  before_action :set_review, only: [:destroy]
+
+  def create
+    unless can_review?
+      redirect_to @offering, alert: 'You can only review offerings you have completed.'
+      return
+    end
+
+    @review = @offering.reviews.build(review_params.merge(user: current_user))
+    if @review.save
+      redirect_to @offering, notice: 'Review created successfully.'
+    else
+      @reviews = @offering.reviews.includes(:user)
+      render 'offerings/show', status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    if @review.user == current_user
+      @review.destroy
+    end
+    redirect_to @offering
+  end
+
+  private
+
+  def set_offering
+    @offering = Offering.find(params[:offering_id])
+  end
+
+  def set_review
+    @review = @offering.reviews.find(params[:id])
+  end
+
+  def review_params
+    params.require(:review).permit(:rating, :comment)
+  end
+
+  def can_review?
+    @offering.bookings.where(user: current_user, status: :completed).exists?
+  end
+end

--- a/app/models/offering.rb
+++ b/app/models/offering.rb
@@ -1,6 +1,7 @@
 class Offering < ApplicationRecord
   belongs_to :user
   has_many :bookings, dependent: :destroy
+  has_many :reviews, dependent: :destroy
   
   validates :title, presence: true, length: { minimum: 5, maximum: 100 }
   validates :description, presence: true, length: { minimum: 20, maximum: 1000 }

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -1,0 +1,7 @@
+class Review < ApplicationRecord
+  belongs_to :user
+  belongs_to :offering
+
+  validates :rating, presence: true, inclusion: { in: 1..5 }
+  validates :comment, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,10 +24,11 @@ class User < ApplicationRecord
 
   # Offerings association
   has_many :offerings, dependent: :destroy
-  
+
   # Booking associations
   has_many :bookings, dependent: :destroy  # Bookings I've made as traveler
   has_many :host_bookings, through: :offerings, source: :bookings  # Bookings for my offerings
+  has_many :reviews, dependent: :destroy
 
   has_one_attached :profile_picture
 

--- a/app/views/offerings/show.html.erb
+++ b/app/views/offerings/show.html.erb
@@ -56,10 +56,38 @@
           </div>
         </div>
 
+        <div class="mb-8">
+          <h2 class="text-xl font-semibold mb-4">Reviews</h2>
+          <% @reviews.each do |review| %>
+            <div class="mb-4">
+              <div class="font-semibold"><%= review.user.display_name %></div>
+              <div class="text-yellow-500">Rating: <%= review.rating %>/5</div>
+              <p class="text-gray-700"><%= review.comment %></p>
+              <% if review.user == current_user %>
+                <%= link_to 'Delete', offering_review_path(@offering, review), method: :delete,
+                    data: { confirm: 'Are you sure?' }, class: 'text-red-500 text-sm' %>
+              <% end %>
+            </div>
+          <% end %>
+          <% if @can_review %>
+            <%= form_with model: [@offering, @review], local: true do |f| %>
+              <div class="mb-2">
+                <%= f.label :rating %>
+                <%= f.number_field :rating, in: 1..5 %>
+              </div>
+              <div class="mb-2">
+                <%= f.label :comment %>
+                <%= f.text_area :comment %>
+              </div>
+              <%= f.submit 'Submit Review', class: 'bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md' %>
+            <% end %>
+          <% end %>
+        </div>
+
         <% if @offering.user == current_user %>
           <div class="border-t pt-6">
             <div class="flex space-x-4">
-              <%= link_to "Edit Offering", edit_offering_path(@offering), 
+              <%= link_to "Edit Offering", edit_offering_path(@offering),
                   class: "bg-blue-500 hover:bg-blue-600 text-white px-6 py-3 rounded-md font-medium transition-colors" %>
               <%= link_to "Delete Offering", @offering, method: :delete, 
                   data: { confirm: "Are you sure you want to delete this offering?" },

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
   # Offerings with nested bookings
   resources :offerings do
     resources :bookings, only: [:new, :create]
+    resources :reviews, only: [:create, :destroy]
   end
 
   # Bookings management

--- a/spec/controllers/reviews_controller_spec.rb
+++ b/spec/controllers/reviews_controller_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe ReviewsController, type: :controller do
+  let(:offering) { create(:offering) }
+  let(:user) { create(:user) }
+
+  before do
+    sign_in user
+  end
+
+  describe 'POST #create' do
+    context 'with completed booking' do
+      before { create(:booking, :completed, user: user, offering: offering) }
+
+      it 'creates a review' do
+        expect {
+          post :create, params: { offering_id: offering.id, review: { rating: 4, comment: 'Nice' } }
+        }.to change(Review, :count).by(1)
+        expect(response).to redirect_to(offering)
+      end
+    end
+
+    context 'without completed booking' do
+      it 'does not create a review' do
+        expect {
+          post :create, params: { offering_id: offering.id, review: { rating: 4, comment: 'Nice' } }
+        }.not_to change(Review, :count)
+        expect(response).to redirect_to(offering)
+        expect(flash[:alert]).to eq('You can only review offerings you have completed.')
+      end
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    let!(:review) { create(:review, offering: offering, user: user) }
+
+    it 'destroys the review' do
+      expect {
+        delete :destroy, params: { offering_id: offering.id, id: review.id }
+      }.to change(Review, :count).by(-1)
+      expect(response).to redirect_to(offering)
+    end
+  end
+end

--- a/spec/factories/reviews.rb
+++ b/spec/factories/reviews.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :review do
+    association :user
+    association :offering
+    rating { 5 }
+    comment { "Great experience!" }
+  end
+end

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe Review, type: :model do
+  describe 'associations' do
+    it { should belong_to(:user) }
+    it { should belong_to(:offering) }
+  end
+
+  describe 'validations' do
+    it { should validate_presence_of(:rating) }
+    it { should validate_inclusion_of(:rating).in_range(1..5) }
+    it { should validate_presence_of(:comment) }
+  end
+end


### PR DESCRIPTION
## Summary
- Add Review model and controller for users to rate offerings
- Display reviews on offering page with form for eligible users
- Cover model validations and review permissions with tests

## Testing
- `bundle exec rspec spec/models/review_spec.rb spec/controllers/reviews_controller_spec.rb` *(fails: bundler: command not found: rspec)*

------
https://chatgpt.com/codex/tasks/task_b_68b5d43c55b083309d4e4969e89aa28e