### PR TITLE
Add sign-up call to action on home page

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -160,6 +160,15 @@
       </div>
     </div>
   </section>
+
+  <section class="signup-cta py-16 bg-blue-600 text-white text-center">
+    <div class="container mx-auto px-4">
+      <h2 class="text-3xl font-bold mb-4">Join VisitMeet Today</h2>
+      <p class="mb-6">Sign up for free and connect with locals around the world.</p>
+      <%= link_to 'Create an Account', new_user_registration_path,
+          class: 'inline-block px-8 py-3 bg-white text-blue-600 font-semibold rounded-full shadow hover:bg-gray-100' %>
+    </div>
+  </section>
 </main>
 
 <script>


### PR DESCRIPTION
## Summary
- Encourage registration by adding a sign-up call to action on the home page

## Testing
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*
- `bundle install` *(fails: 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_b_68b69e1b69d0833086d8a2a38ddac687