### PR TITLE
Rebuild messaging tables with read receipts and typing indicators

### DIFF
--- a/db/migrate/20250720050556_add_read_at_to_messages.rb
+++ b/db/migrate/20250720050556_add_read_at_to_messages.rb
@@ -1,5 +1,0 @@
-class AddReadAtToMessages < ActiveRecord::Migration[7.1]
-  def change
-    add_column :messages, :read_at, :datetime
-  end
-end

--- a/db/migrate/20250720050836_add_typing_user_id_to_conversations.rb
+++ b/db/migrate/20250720050836_add_typing_user_id_to_conversations.rb
@@ -1,5 +1,0 @@
-class AddTypingUserIdToConversations < ActiveRecord::Migration[7.1]
-  def change
-    add_column :conversations, :typing_user_id, :integer
-  end
-end

--- a/db/migrate/20250720090000_create_conversations.rb
+++ b/db/migrate/20250720090000_create_conversations.rb
@@ -1,0 +1,13 @@
+class CreateConversations < ActiveRecord::Migration[7.1]
+  def change
+    create_table :conversations do |t|
+      t.references :sender, null: false, foreign_key: { to_table: :users }
+      t.references :recipient, null: false, foreign_key: { to_table: :users }
+      t.references :typing_user, foreign_key: { to_table: :users }
+
+      t.timestamps
+    end
+
+    add_index :conversations, [:sender_id, :recipient_id], unique: true
+  end
+end

--- a/db/migrate/20250720090100_create_messages.rb
+++ b/db/migrate/20250720090100_create_messages.rb
@@ -1,0 +1,15 @@
+class CreateMessages < ActiveRecord::Migration[7.1]
+  def change
+    create_table :messages do |t|
+      t.references :conversation, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.text :body, null: false
+      t.datetime :read_at
+
+      t.timestamps
+    end
+
+    add_index :messages, :read_at
+    add_index :messages, [:conversation_id, :created_at]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_07_20_050836) do
+ActiveRecord::Schema[7.1].define(version: 2025_07_20_090100) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -74,11 +74,13 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_20_050836) do
   create_table "conversations", force: :cascade do |t|
     t.bigint "sender_id", null: false
     t.bigint "recipient_id", null: false
+    t.bigint "typing_user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "typing_user_id"
     t.index ["recipient_id"], name: "index_conversations_on_recipient_id"
+    t.index ["sender_id", "recipient_id"], name: "index_conversations_on_sender_id_and_recipient_id", unique: true
     t.index ["sender_id"], name: "index_conversations_on_sender_id"
+    t.index ["typing_user_id"], name: "index_conversations_on_typing_user_id"
   end
 
   create_table "follows", force: :cascade do |t|
@@ -98,11 +100,13 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_20_050836) do
   create_table "messages", force: :cascade do |t|
     t.bigint "conversation_id", null: false
     t.bigint "user_id", null: false
-    t.text "body"
+    t.text "body", null: false
+    t.datetime "read_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.datetime "read_at"
     t.index ["conversation_id"], name: "index_messages_on_conversation_id"
+    t.index ["conversation_id", "created_at"], name: "index_messages_on_conversation_id_and_created_at"
+    t.index ["read_at"], name: "index_messages_on_read_at"
     t.index ["user_id"], name: "index_messages_on_user_id"
   end
 
@@ -230,6 +234,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_20_050836) do
   add_foreign_key "bookings", "users"
   add_foreign_key "conversations", "users", column: "recipient_id"
   add_foreign_key "conversations", "users", column: "sender_id"
+  add_foreign_key "conversations", "users", column: "typing_user_id"
   add_foreign_key "follows", "users", column: "followed_id"
   add_foreign_key "follows", "users", column: "follower_id"
   add_foreign_key "messages", "conversations"


### PR DESCRIPTION
## Summary
- replace incomplete messaging migrations with full conversation/message tables
- add read receipt and typing indicator fields with indexes and foreign keys

## Testing
- `bin/rails db:drop db:create db:migrate` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.2.2)*
- `bin/rails test` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.2.2)*

------
https://chatgpt.com/codex/tasks/task_b_68b6a559a6408330b5a80c9ee1fe6206