### PR TITLE
Handle existing user_tags table during migration

### DIFF
--- a/db/migrate/20250901000000_create_user_tags.rb
+++ b/db/migrate/20250901000000_create_user_tags.rb
@@ -1,10 +1,14 @@
 class CreateUserTags < ActiveRecord::Migration[7.1]
-  def change
-    create_table :user_tags do |t|
+  def up
+    create_table :user_tags, if_not_exists: true do |t|
       t.references :user, null: false, foreign_key: true
       t.references :tag, null: false, foreign_key: true
 
       t.timestamps
     end
+  end
+
+  def down
+    drop_table :user_tags, if_exists: true
   end
 end


### PR DESCRIPTION
## Summary
- make user_tags migration idempotent and reversible with `if_not_exists`/`if_exists`

## Testing
- `bundle exec rspec` *(fails: command not found)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_b_68b6b22258908330b3c7c2e42543d13f