### PR TITLE
Reenable asset pipeline for importmap controllers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 ruby "3.2.3"
 gem "rails", "~> 7.1.4"
-# gem "sprockets-rails"
+gem "sprockets-rails"
 gem "pg", "~> 1.1"
 gem "puma", ">= 5.0"
 gem "importmap-rails"

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,0 +1,4 @@
+//= link_tree ../images
+//= link_directory ../stylesheets .css
+//= link_tree ../../javascript .js
+//= link_tree ../../../vendor/javascript .js

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -20,15 +20,12 @@ Rails.application.configure do
   # key such as config/credentials/production.key. This key is used to decrypt credentials (and other encrypted files).
   # config.require_master_key = true
 
-  # Serve static files from the `/public` folder when the environment
-  # variable `RAILS_SERVE_STATIC_FILES` is present. This aligns with our
-  # importmap and Tailwind setup which outputs built assets directly to
-  # `public` without using the Sprockets pipeline.
-  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
+  # Serve static files from the `/public` folder so Importmap and Tailwind
+  # assets are available in production.
+  config.public_file_server.enabled = true
 
-  # Sprockets has been removed, so avoid any `config.assets` settings that
-  # were previously used for the old asset pipeline.
-  # config.assets.compile = true
+  # Enable the asset pipeline to compile JavaScript modules for Importmap.
+  config.assets.compile = true
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache


### PR DESCRIPTION
## Summary
- restore sprockets-rails and manifest so importmap controllers are compiled
- serve static assets in production and allow runtime asset compilation

## Testing
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*
- `bundle exec rails assets:precompile` *(fails: bundler: command not found: rails)*

------
https://chatgpt.com/codex/tasks/task_b_68b6b96fc74c833086cda7689f367dec