### PR TITLE
Use importmap keys for JavaScript modules

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -4,6 +4,6 @@ import "controllers" // Loads all files in app/javascript/controllers/
 import "channels"   // Loads all files in app/javascript/channels/
 import "autosuggestion"
 import "autocomplete"
-import "./custom/messages" // Since messages.js isn’t pinned, use relative path for now
+import "messages"
 
 Rails.start()

--- a/app/javascript/channels/conversation_channel.js
+++ b/app/javascript/channels/conversation_channel.js
@@ -1,4 +1,4 @@
-import consumer from "./consumer"
+import consumer from "channels/consumer"
 
 consumer.subscriptions.create("ConversationChannel", {
   connected() {

--- a/app/javascript/channels/index.js
+++ b/app/javascript/channels/index.js
@@ -1,2 +1,3 @@
 // Import all the channels to be used by Action Cable
-export * from "./conversation_channel"
+export * from "channels/conversation_channel"
+

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -6,8 +6,8 @@ import { definitionsFromContext } from "@hotwired/stimulus-loading"
 
 import "controllers"
 import "jquery"
-import "./custom/autocomplete"
-import "./custom/autosuggestion"
+import "autocomplete"
+import "autosuggestion"
 
 // Expose jQuery globally if needed
 window.$ = window.jQuery = jQuery


### PR DESCRIPTION
## Summary
- replace relative paths with importmap keys in application bootstrap
- load Stimulus helpers and channels via importmap scopes
- standardize Action Cable channel imports

## Testing
- `bin/importmap json` *(fails: Could not find rails-7.1.4...)*
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*

------
https://chatgpt.com/codex/tasks/task_b_68b6c59380cc8330b3a5e3ccf9842d9a