### PR TITLE
Expand user search vector

### DIFF
--- a/db/migrate/20250901001000_add_search_vector_to_users.rb
+++ b/db/migrate/20250901001000_add_search_vector_to_users.rb
@@ -9,11 +9,18 @@ class AddSearchVectorToUsers < ActiveRecord::Migration[7.1]
         NEW.search_vector :=
           setweight(to_tsvector('english', coalesce(NEW.country, '')), 'A') ||
           setweight(to_tsvector('english', coalesce((
-            SELECT string_agg(tags.name, ' ')
-            FROM tags
-            JOIN user_tags ON user_tags.tag_id = tags.id
-            WHERE user_tags.user_id = NEW.id
-          ), '')), 'B');
+            SELECT string_agg(location_tags.location, ' ')
+            FROM location_tags
+            JOIN user_location_tags ON user_location_tags.location_tag_id = location_tags.id
+            WHERE user_location_tags.user_id = NEW.id
+          ), '')), 'B') ||
+          setweight(to_tsvector('english', coalesce((
+            SELECT string_agg(profession_tags.profession, ' ')
+            FROM profession_tags
+            JOIN user_profession_tags ON user_profession_tags.profession_tag_id = profession_tags.id
+            WHERE user_profession_tags.user_id = NEW.id
+          ), '')), 'B') ||
+          setweight(to_tsvector('english', coalesce(NEW.bio, '')), 'C');
         RETURN NEW;
       END
       $$ LANGUAGE plpgsql;
@@ -27,25 +34,53 @@ class AddSearchVectorToUsers < ActiveRecord::Migration[7.1]
         UPDATE users SET search_vector =
           setweight(to_tsvector('english', coalesce(country, '')), 'A') ||
           setweight(to_tsvector('english', coalesce((
-            SELECT string_agg(tags.name, ' ')
-            FROM tags
-            JOIN user_tags ON user_tags.tag_id = tags.id
-            WHERE user_tags.user_id = users.id
-          ), '')), 'B')
-        WHERE id = NEW.user_id;
+            SELECT string_agg(location_tags.location, ' ')
+            FROM location_tags
+            JOIN user_location_tags ON user_location_tags.location_tag_id = location_tags.id
+            WHERE user_location_tags.user_id = users.id
+          ), '')), 'B') ||
+          setweight(to_tsvector('english', coalesce((
+            SELECT string_agg(profession_tags.profession, ' ')
+            FROM profession_tags
+            JOIN user_profession_tags ON user_profession_tags.profession_tag_id = profession_tags.id
+            WHERE user_profession_tags.user_id = users.id
+          ), '')), 'B') ||
+          setweight(to_tsvector('english', coalesce(bio, '')), 'C')
+        WHERE id = COALESCE(NEW.user_id, OLD.user_id);
         RETURN NULL;
       END
       $$ LANGUAGE plpgsql;
 
-      CREATE TRIGGER user_tags_search_vector_refresh
-      AFTER INSERT OR DELETE OR UPDATE ON user_tags
+      CREATE TRIGGER user_location_tags_search_vector_refresh
+      AFTER INSERT OR DELETE OR UPDATE ON user_location_tags
       FOR EACH ROW EXECUTE FUNCTION refresh_users_search_vector();
+
+      CREATE TRIGGER user_profession_tags_search_vector_refresh
+      AFTER INSERT OR DELETE OR UPDATE ON user_profession_tags
+      FOR EACH ROW EXECUTE FUNCTION refresh_users_search_vector();
+
+      UPDATE users SET search_vector =
+        setweight(to_tsvector('english', coalesce(country, '')), 'A') ||
+        setweight(to_tsvector('english', coalesce((
+          SELECT string_agg(location_tags.location, ' ')
+          FROM location_tags
+          JOIN user_location_tags ON user_location_tags.location_tag_id = location_tags.id
+          WHERE user_location_tags.user_id = users.id
+        ), '')), 'B') ||
+        setweight(to_tsvector('english', coalesce((
+          SELECT string_agg(profession_tags.profession, ' ')
+          FROM profession_tags
+          JOIN user_profession_tags ON user_profession_tags.profession_tag_id = profession_tags.id
+          WHERE user_profession_tags.user_id = users.id
+        ), '')), 'B') ||
+        setweight(to_tsvector('english', coalesce(bio, '')), 'C');
     SQL
   end
 
   def down
     execute <<-SQL
-      DROP TRIGGER IF EXISTS user_tags_search_vector_refresh ON user_tags;
+      DROP TRIGGER IF EXISTS user_location_tags_search_vector_refresh ON user_location_tags;
+      DROP TRIGGER IF EXISTS user_profession_tags_search_vector_refresh ON user_profession_tags;
       DROP FUNCTION IF EXISTS refresh_users_search_vector();
       DROP TRIGGER IF EXISTS users_search_vector_update ON users;
       DROP FUNCTION IF EXISTS users_search_vector_trigger();


### PR DESCRIPTION
## Summary
- include country, location tags, profession tags, and bio in users.search_vector with weighted tsvectors
- refresh users.search_vector on related tag changes and backfill existing records

## Testing
- `bundle exec rspec` *(fails: command not found: rspec)*
- `bundle exec rubocop` *(fails: command not found: rubocop)*

------
https://chatgpt.com/codex/tasks/task_b_68b6db8bc32883309dc44ea7c80c7975