### PR TITLE
Add search feature test coverage and factories

### DIFF
--- a/app/controllers/search_suggestions_controller.rb
+++ b/app/controllers/search_suggestions_controller.rb
@@ -1,6 +1,9 @@
 class SearchSuggestionsController < ApplicationController
   def index
     q = params[:q].to_s.strip.downcase
+    if q.blank?
+      return render json: { error: 'q parameter is required' }, status: :bad_request
+    end
 
     suggestions = Rails.cache.fetch(["search_suggestions", q], expires_in: 1.hour) do
       {

--- a/spec/factories/location_tags.rb
+++ b/spec/factories/location_tags.rb
@@ -2,7 +2,6 @@
 
 FactoryBot.define do
   factory :location_tag do
-    # use a unique sequence so you can create multiple different tags if needed
-    location { "validlocation" }
+    sequence(:location) { |n| "location#{n}" }
   end
 end

--- a/spec/factories/profession_tags.rb
+++ b/spec/factories/profession_tags.rb
@@ -2,6 +2,6 @@
 
 FactoryBot.define do
   factory :profession_tag do
-        profession { "validprofession" }
+    sequence(:profession) { |n| "profession#{n}" }
   end
 end

--- a/spec/requests/search_suggestions_spec.rb
+++ b/spec/requests/search_suggestions_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe "SearchSuggestions", type: :request do
+  describe "GET /search_suggestions" do
+    it "returns tags and locations matching the query" do
+      create(:tag, name: 'photography')
+      create(:location_tag, location: 'phuket')
+
+      get search_suggestions_path, params: { q: 'ph' }
+
+      expect(response).to have_http_status(:success)
+      data = JSON.parse(response.body)
+      expect(data['tags']).to include('photography')
+      expect(data['locations']).to include('phuket')
+    end
+
+    it "returns bad request when query is missing" do
+      get search_suggestions_path
+
+      expect(response).to have_http_status(:bad_request)
+      data = JSON.parse(response.body)
+      expect(data['error']).to be_present
+    end
+  end
+end

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -36,4 +36,43 @@ RSpec.describe SearchService do
     expect(results[:offerings].count).to eq(1)
     expect(results[:reviews].count).to eq(1)
   end
+
+  it 'handles multiple keywords across resources' do
+    user = create(:user)
+    tag1 = create(:tag, name: 'photography')
+    tag2 = create(:tag, name: 'tour')
+    UserTag.create!(user: user, tag: tag1)
+    UserTag.create!(user: user, tag: tag2)
+
+    offering = create(:offering, title: 'Photography tour', description: 'Tour with photography', location: 'nepal', user: user)
+    review_user = create(:user)
+    review = create(:review, offering: offering, user: review_user, comment: 'Great photography tour')
+
+    results = SearchService.new(%w[photography tour]).call
+
+    expect(results[:users]).to include(user)
+    expect(results[:offerings]).to include(offering)
+    expect(results[:reviews]).to include(review)
+  end
+
+  it 'returns empty results when no matches found' do
+    create(:user)
+    results = SearchService.new(['nonexistent']).call
+
+    expect(results[:users]).to be_empty
+    expect(results[:offerings]).to be_empty
+    expect(results[:reviews]).to be_empty
+  end
+
+  it 'supports fuzzy matching for typos' do
+    user = create(:user)
+    offering = create(:offering, title: 'Hiking adventure', description: 'Enjoy hiking', location: 'nepal', user: user)
+    review_user = create(:user)
+    review = create(:review, offering: offering, user: review_user, comment: 'Great hiking experience')
+
+    results = SearchService.new(['hikng']).call
+
+    expect(results[:offerings]).to include(offering)
+    expect(results[:reviews]).to include(review)
+  end
 end

--- a/spec/system/search_spec.rb
+++ b/spec/system/search_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe 'Search', type: :system do
+  it 'adds and removes search chips with live updates', js: true do
+    user = create(:user)
+    tag = create(:tag, name: 'photography')
+    UserTag.create!(user: user, tag: tag)
+    create(:offering, title: 'Photography tour', user: user, description: 'Great shots', location: 'nepal')
+
+    visit search_results_path
+
+    find('[data-search-tags-target="input"]').fill_in(with: 'photography')
+    find('[data-search-tags-target="input"]').send_keys(:enter)
+
+    expect(page).to have_css('[data-search-tags-target="tags"]', text: 'photography')
+    expect(page).to have_content('Photography tour')
+
+    within('[data-search-tags-target="tags"]') do
+      click_button '×'
+    end
+
+    expect(page).to have_content('No matches found')
+  end
+end


### PR DESCRIPTION
## Summary
- expand `SearchService` specs for multiple keywords, empty results, and fuzzy matches
- validate search suggestions JSON responses and missing query error
- add system spec for chip-based search updates via Turbo
- add factory sequences for `LocationTag` and `ProfessionTag`

## Testing
- `bundle exec rspec spec/services/search_service_spec.rb spec/requests/search_suggestions_spec.rb spec/system/search_spec.rb` *(fails: bundler: command not found: rspec)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_b_68b6e47f77a483309dd578bb66b2b0da