### PR TITLE
Handle missing search tags in results

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -1,10 +1,10 @@
 class ResultsController < ApplicationController
   def index
-    tags = params[:tags].to_s.split(',')
+    tags = params[:tags].to_s.split(',').reject(&:blank?)
     results = SearchService.new(tags).call
-    @profiles = results[:users].includes(:tags)
-    @offerings = results[:offerings]
-    @reviews = results[:reviews]
+    @profiles = results.fetch(:users, User.none).includes(:tags)
+    @offerings = results.fetch(:offerings, Offering.none)
+    @reviews = results.fetch(:reviews, Review.none)
     @search_tags = tags
   end
 end

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -3,7 +3,7 @@
     <h1 class="text-3xl font-bold mb-4 text-center">Local Hosts & Guides</h1>
 
     <%= form_with url: search_results_path, method: :get, class: "mb-6", data: { turbo_frame: "search_results", controller: "search-tags" } do |f| %>
-      <input type="hidden" name="tags" value="<%= @search_tags.join(',') %>" data-search-tags-target="hidden">
+      <input type="hidden" name="tags" value="<%= Array(@search_tags).join(',') %>" data-search-tags-target="hidden">
       <input type="text" placeholder="Add tag and press enter" class="w-full px-4 py-2 border rounded" data-search-tags-target="input" data-action="keydown->search-tags#addTag keyup->search-tags#fetchSuggestions">
       <ul class="mt-1 bg-white border rounded shadow" data-search-tags-target="suggestions"></ul>
 


### PR DESCRIPTION
## Summary
- Guard against blank tags and missing search results when rendering the results page
- Default search form to use an empty tag list to prevent join errors

## Testing
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*
- `bundle install` *(fails: 403 "Forbidden" fetching gems)*

------
https://chatgpt.com/codex/tasks/task_b_68b76e489c3c8330a1ee19e97a6a96eb