### PR TITLE
Improve search robustness and handle missing reviews table

### DIFF
--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -10,7 +10,7 @@
       <turbo-frame id="search_results">
         <div class="flex flex-wrap gap-2 mb-2" data-search-tags-target="tags"></div>
 
-        <% if @profiles.any? %>
+        <% if @profiles.present? %>
           <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             <% @profiles.each do |profile| %>
               <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-6 hover:shadow-lg transition-shadow">
@@ -44,7 +44,7 @@
           </div>
         <% end %>
 
-        <% if @offerings.any? %>
+        <% if @offerings.present? %>
           <h2 class="text-2xl font-bold mt-10 mb-4">Offerings</h2>
           <ul class="space-y-4">
             <% @offerings.each do |offering| %>
@@ -56,7 +56,7 @@
           </ul>
         <% end %>
 
-        <% if @reviews.any? %>
+        <% if @reviews.present? %>
           <h2 class="text-2xl font-bold mt-10 mb-4">Reviews</h2>
           <ul class="space-y-4">
             <% @reviews.each do |review| %>
@@ -68,7 +68,7 @@
           </ul>
         <% end %>
 
-        <% unless @profiles.any? || @offerings.any? || @reviews.any? %>
+        <% unless @profiles.present? || @offerings.present? || @reviews.present? %>
           <div class="text-center py-12">
             <div class="text-gray-400 text-6xl mb-4">🔍</div>
             <h2 class="text-2xl font-semibold text-gray-600 dark:text-gray-300 mb-2">No matches found</h2>

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -64,4 +64,12 @@ RSpec.describe SearchService do
     expect(results[:reviews]).to be_empty
   end
 
+  it 'returns empty reviews when reviews table is missing' do
+    service = SearchService.new(['anything'])
+    allow(service).to receive(:reviews_table?).and_return(false)
+
+    results = service.call
+    expect(results[:reviews]).to eq([])
+  end
+
 end


### PR DESCRIPTION
## Summary
- Guard search queries from missing `reviews` table
- Rescue search errors with Rollbar context and safe fallbacks
- Protect search results view against nil collections and add spec for missing review table

## Testing
- `bundle exec rspec spec/services/search_service_spec.rb` *(fails: bundler: command not found: rspec)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_b_68b77401a5808330855c515cc2bb064b