### PR TITLE
Refactor search for multi-field matching

### DIFF
--- a/spec/system/search_spec.rb
+++ b/spec/system/search_spec.rb
@@ -21,4 +21,17 @@ RSpec.describe 'Search', type: :system do
 
     expect(page).to have_content('No matches found')
   end
+
+  it 'finds users by location', js: true do
+    user = create(:user, full_name: 'Guide In Pokhara')
+    location_tag = create(:location_tag, location: 'pokhara')
+    UserLocationTag.create!(user: user, location_tag: location_tag)
+
+    visit search_results_path
+
+    find('[data-search-tags-target="input"]').fill_in(with: 'pokhara')
+    find('[data-search-tags-target="input"]').send_keys(:enter)
+
+    expect(page).to have_content('Guide In Pokhara')
+  end
 end


### PR DESCRIPTION
## Summary
- replace tsvector search with case-insensitive partial matching across usernames, bios, locations, profession tags and user tags
- search offerings and reviews with similar flexible ILIKE logic
- add system spec ensuring users can be found by location

## Testing
- `bundle exec rubocop app/services/search_service.rb spec/system/search_spec.rb` (failed: bundler could not find gem "rubocop")
- `bundle install` (failed: 403 "Forbidden")
- `bundle exec rspec spec/system/search_spec.rb` (failed: bundler could not find gem "rspec")

------
https://chatgpt.com/codex/tasks/task_b_68b7770ca02483308a8b9202f89d2188