### PR TITLE
Add editable bio to profile page

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -70,7 +70,7 @@ class ProfilesController < ApplicationController
   end
 
   def profile_params
-    permitted = [:country]
+    permitted = [:country, :bio]
     permitted &= User.column_names.map(&:to_sym)
     params.require(:user).permit(*permitted)
   end

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -31,7 +31,11 @@
                      { include_blank: 'Select your country' },
                      { class: "block w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500", id: "country_select" } %>
       </div>
-      <%= f.submit "Update Country", class: "bg-blue-500 text-white px-4 py-2 rounded-md hover:bg-blue-600" %>
+      <div class="mb-4">
+        <%= f.label :bio, "Bio", class: "block text-gray-700 dark:text-gray-200 font-medium mb-2" %>
+        <%= f.text_area :bio, rows: 4, class: "block w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+      </div>
+      <%= f.submit "Update Profile", class: "bg-blue-500 text-white px-4 py-2 rounded-md hover:bg-blue-600" %>
     <% end %>
   </div>
 <% end %>
@@ -45,6 +49,9 @@
           </h1>
           <p class="text-gray-600 dark:text-gray-300 mb-1"><%= @user.display_name %></p>
           <p class="text-sm text-gray-500 dark:text-gray-400 mb-2">@<%= @user.username %></p>
+          <% if @user.bio.present? %>
+            <p class="text-gray-700 dark:text-gray-300 mb-2 whitespace-pre-line"><%= @user.bio %></p>
+          <% end %>
 
           <div class="flex space-x-4 mt-2">
             <div class="text-center">

--- a/db/migrate/20250902001000_add_bio_to_users.rb
+++ b/db/migrate/20250902001000_add_bio_to_users.rb
@@ -1,0 +1,5 @@
+class AddBioToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :bio, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_09_01_002000) do
+ActiveRecord::Schema[7.1].define(version: 2025_09_02_001000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -223,6 +223,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_01_002000) do
     t.string "full_name"
     t.string "provider"
     t.string "uid"
+    t.text "bio"
     t.string "country"
     t.tsvector "search_vector"
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/spec/controllers/profiles_controller_spec.rb
+++ b/spec/controllers/profiles_controller_spec.rb
@@ -45,6 +45,13 @@ RSpec.describe ProfilesController, type: :controller do
     end
   end
 
+  describe "PATCH #update" do
+    it "updates the user's bio" do
+      patch :update, params: { user: { bio: "New bio" } }
+      expect(user.reload.bio).to eq("New bio")
+    end
+  end
+
   describe "POST #add_tag" do
     context "with a new location tag" do
       it "adds a new location tag to the user" do


### PR DESCRIPTION
## Summary
- allow users to add a bio to their profile
- display and edit bio on profile page
- test profile update including bio field

## Testing
- `bundle exec rails db:migrate` *(fails: command not found: rails)*
- `bundle exec rspec spec/controllers/profiles_controller_spec.rb` *(fails: command not found: rspec)*

------
https://chatgpt.com/codex/tasks/task_b_68b966218fc483309bbf31aaf1a0486c