### PR TITLE
Split bookings into user and host views with sidebar navigation

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -5,8 +5,11 @@ class BookingsController < ApplicationController
   before_action :authorize_booking_access, only: [:show, :edit, :update, :destroy]
 
   def index
-    @traveler_bookings = current_user.bookings.includes(:offering).order(created_at: :desc)
-    @host_bookings = current_user.host_bookings.includes(:user, :offering).order(created_at: :desc)
+    @bookings = current_user.bookings.includes(:offering).order(created_at: :desc)
+  end
+
+  def hosted
+    @bookings = current_user.host_bookings.includes(:user, :offering).order(created_at: :desc)
   end
 
   def show

--- a/app/views/bookings/_sidebar.html.erb
+++ b/app/views/bookings/_sidebar.html.erb
@@ -1,0 +1,6 @@
+<nav class="bg-white dark:bg-gray-800 rounded-lg shadow-md p-4 space-y-2">
+  <%= link_to "My Bookings", bookings_path,
+      class: "block px-4 py-2 rounded-md #{current_page?(bookings_path) ? 'bg-blue-600 text-white' : 'text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700'}" %>
+  <%= link_to "Hosted Bookings", hosted_bookings_path,
+      class: "block px-4 py-2 rounded-md #{current_page?(hosted_bookings_path) ? 'bg-blue-600 text-white' : 'text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700'}" %>
+</nav>

--- a/app/views/bookings/hosted.html.erb
+++ b/app/views/bookings/hosted.html.erb
@@ -5,7 +5,7 @@
     </aside>
     <div class="flex-1">
       <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6">
-        <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-8">My Bookings</h1>
+        <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-8">Hosted Bookings</h1>
 
         <% if @bookings.any? %>
           <div class="space-y-4">
@@ -38,21 +38,25 @@
                     </div>
 
                     <div class="mt-2 text-sm text-gray-600 dark:text-gray-300">
-                      <span class="font-medium">Location:</span>
-                      <%= booking.offering.location.titleize %>
+                      <span class="font-medium">Traveler:</span>
+                      <%= booking.user.display_name %>
                     </div>
 
-                    <div class="mt-2 text-sm text-gray-600 dark:text-gray-300">
-                      <span class="font-medium">Host:</span>
-                      <%= booking.offering.user.display_name %>
-                    </div>
+                    <% if booking.message.present? %>
+                      <div class="mt-2 text-sm text-gray-600 dark:text-gray-300">
+                        <span class="font-medium">Message:</span>
+                        <%= booking.message %>
+                      </div>
+                    <% end %>
                   </div>
 
                   <div class="flex gap-2 ml-4">
                     <%= link_to "View", booking_path(booking), class: "px-3 py-1 text-sm border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700 dark:bg-gray-900" %>
-                    <% if booking.can_be_cancelled? %>
-                      <%= button_to "Cancel", cancel_booking_path(booking), method: :patch,
-                          data: { confirm: "Are you sure you want to cancel this booking?" },
+                    <% if booking.can_be_accepted? %>
+                      <%= button_to "Accept", accept_booking_path(booking), method: :patch,
+                          class: "px-3 py-1 text-sm bg-green-600 text-white rounded-md hover:bg-green-700" %>
+                      <%= button_to "Decline", decline_booking_path(booking), method: :patch,
+                          data: { confirm: "Are you sure you want to decline this booking?" },
                           class: "px-3 py-1 text-sm border border-red-300 text-red-600 rounded-md hover:bg-red-50" %>
                     <% end %>
                   </div>
@@ -62,8 +66,8 @@
           </div>
         <% else %>
           <div class="text-center py-12">
-            <p class="text-gray-500 dark:text-gray-400 text-lg">You haven't made any bookings yet.</p>
-            <%= link_to "Browse Offerings", offerings_path, class: "mt-4 inline-block bg-blue-600 text-white px-6 py-2 rounded-md hover:bg-blue-700" %>
+            <p class="text-gray-500 dark:text-gray-400 text-lg">You haven't hosted anyone yet. Your hosted bookings will show up here.</p>
+            <%= link_to "Create an Offering", new_offering_path, class: "mt-4 inline-block bg-blue-600 text-white px-6 py-2 rounded-md hover:bg-blue-700" %>
           </div>
         <% end %>
       </div>

--- a/app/views/bookings/show.html.erb
+++ b/app/views/bookings/show.html.erb
@@ -129,7 +129,7 @@
 
     <!-- Navigation -->
     <div class="mt-8 flex justify-between">
-      <%= link_to "← Back to Bookings", bookings_path, 
+      <%= link_to "← Back to Bookings", (@booking.offering.user == current_user ? hosted_bookings_path : bookings_path),
           class: "inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 dark:bg-gray-900" %>
       
       <% if @booking.offering.user != current_user %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,9 @@ Rails.application.routes.draw do
 
   # Bookings management
   resources :bookings, except: [:new, :create] do
+    collection do
+      get :hosted
+    end
     member do
       patch :accept
       patch :decline

--- a/spec/requests/bookings_spec.rb
+++ b/spec/requests/bookings_spec.rb
@@ -1,53 +1,23 @@
 require 'rails_helper'
 
 RSpec.describe "Bookings", type: :request do
-  describe "GET /index" do
+  let(:user) { create(:user) }
+
+  before do
+    sign_in user
+  end
+
+  describe "GET /bookings" do
     it "returns http success" do
-      get "/bookings/index"
+      get bookings_path
       expect(response).to have_http_status(:success)
     end
   end
 
-  describe "GET /show" do
+  describe "GET /bookings/hosted" do
     it "returns http success" do
-      get "/bookings/show"
+      get hosted_bookings_path
       expect(response).to have_http_status(:success)
     end
   end
-
-  describe "GET /new" do
-    it "returns http success" do
-      get "/bookings/new"
-      expect(response).to have_http_status(:success)
-    end
-  end
-
-  describe "GET /create" do
-    it "returns http success" do
-      get "/bookings/create"
-      expect(response).to have_http_status(:success)
-    end
-  end
-
-  describe "GET /edit" do
-    it "returns http success" do
-      get "/bookings/edit"
-      expect(response).to have_http_status(:success)
-    end
-  end
-
-  describe "GET /update" do
-    it "returns http success" do
-      get "/bookings/update"
-      expect(response).to have_http_status(:success)
-    end
-  end
-
-  describe "GET /destroy" do
-    it "returns http success" do
-      get "/bookings/destroy"
-      expect(response).to have_http_status(:success)
-    end
-  end
-
 end


### PR DESCRIPTION
## Summary
- Split bookings into separate My Bookings and Hosted Bookings pages
- Add sidebar navigation to switch between booking types
- Adjust routes, controller actions, and specs for new views

## Testing
- `bundle exec rspec` *(fails: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68b9caaf418883308c6bf3d89895c821