### PR TITLE
Add photo attachments to user profiles

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -51,6 +51,18 @@ class ProfilesController < ApplicationController
     head :ok
   end
 
+  def add_photo
+    photos = profile_params[:photos]
+    current_user.photos.attach(photos) if photos
+    redirect_to profile_path
+  end
+
+  def remove_photo
+    photo = current_user.photos.find_by(id: params[:photo_id])
+    photo.purge if photo
+    redirect_to profile_path
+  end
+
   def update_picture
     if current_user.update(profile_picture_params)
       redirect_to profile_path, notice: "Profile picture updated successfully."
@@ -80,6 +92,6 @@ class ProfilesController < ApplicationController
   def profile_params
     permitted = [:country, :bio, :languages, :hosting_available]
     permitted &= User.column_names.map(&:to_sym)
-    params.require(:user).permit(*permitted)
+    params.require(:user).permit(*permitted, photos: [])
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,6 +34,7 @@ class User < ApplicationRecord
   has_many :reviews, dependent: :destroy
 
   has_one_attached :profile_picture
+  has_many_attached :photos
 
   # Follower/Following Associations
   has_many :active_relationships, class_name: "Follow",

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -141,10 +141,25 @@
     <!-- Photos -->
     <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6 mt-6">
       <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">Photos</h2>
-      <% if @user.respond_to?(:photos) && @user.photos.attached? %>
+
+      <% if @is_own_profile %>
+        <%= form_with model: @user, url: add_photo_profile_path, method: :post, local: true, html: { multipart: true }, class: "mb-4" do |f| %>
+          <div class="flex items-center gap-2">
+            <%= f.file_field :photos, multiple: true, class: "flex-1 rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700" %>
+            <%= f.submit "Upload", class: "px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700" %>
+          </div>
+        <% end %>
+      <% end %>
+
+      <% if @user.photos.attached? %>
         <div class="grid grid-cols-2 sm:grid-cols-3 gap-4">
           <% @user.photos.each do |photo| %>
-            <%= image_tag photo.variant(resize_to_fill: [300,200]), class: "rounded-lg object-cover w-full h-48" %>
+            <div class="relative group">
+              <%= image_tag photo.variant(resize_to_fill: [300,200]), class: "rounded-lg object-cover w-full h-48" %>
+              <% if @is_own_profile %>
+                <%= link_to "Delete", remove_photo_profile_path(photo_id: photo.id), method: :delete, data: { confirm: "Delete this photo?" }, class: "absolute top-2 right-2 bg-red-600 text-white text-xs rounded px-2 py-1 opacity-0 group-hover:opacity-100" %>
+              <% end %>
+            </div>
           <% end %>
         </div>
       <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,8 @@ Rails.application.routes.draw do
     patch :update_picture
     post :add_tag
     delete :remove_tag
+    post :add_photo
+    delete :remove_photo
   end
 
   resources :users, only: [:show] do


### PR DESCRIPTION
## Summary
- enable multi-photo attachments for users
- support photo upload and removal via profile routes
- display and manage profile photos from S3-backed ActiveStorage

## Testing
- `bundle exec rspec` *(fails: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed)*

------
https://chatgpt.com/codex/tasks/task_b_68b9d4a4f68c83309548031950ca187d