### PR TITLE
Refactor view cards and standardize Tailwind styling

### DIFF
--- a/app/views/offerings/_card.html.erb
+++ b/app/views/offerings/_card.html.erb
@@ -1,0 +1,29 @@
+<% compact = local_assigns.fetch(:compact, false) %>
+<% show_actions = local_assigns.fetch(:show_actions, false) %>
+<% card_classes = compact ? '' : 'overflow-hidden hover:shadow-lg transition-shadow' %>
+<%= render 'shared/card', classes: card_classes, content: capture do %>
+  <% if compact %>
+    <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+      <%= link_to offering.title, offering_path(offering), class: 'hover:text-blue-600' %>
+    </h3>
+    <p class="text-sm text-gray-500 dark:text-gray-400"><%= offering.location.titleize %></p>
+  <% else %>
+    <h3 class="text-xl font-semibold mb-2"><%= offering.title %></h3>
+    <p class="text-gray-600 dark:text-gray-300 mb-4 line-clamp-3"><%= truncate(offering.description, length: 100) %></p>
+    <div class="flex justify-between items-center mb-4">
+      <span class="text-2xl font-bold text-green-600">$<%= offering.price %></span>
+      <span class="bg-gray-100 dark:bg-gray-800 text-gray-800 dark:text-gray-100 text-sm px-2 py-1 rounded-full">📍 <%= offering.location %></span>
+    </div>
+    <% if show_actions %>
+      <div class="flex space-x-2">
+        <%= link_to 'View', offering,
+            class: 'flex-1 bg-blue-500 hover:bg-blue-600 text-white px-3 py-2 rounded text-center text-sm font-medium transition-colors' %>
+        <%= link_to 'Edit', edit_offering_path(offering),
+            class: 'flex-1 bg-gray-500 dark:bg-gray-700 hover:bg-gray-600 text-white px-3 py-2 rounded text-center text-sm font-medium transition-colors' %>
+        <%= link_to 'Delete', offering, method: :delete,
+            data: { confirm: 'Are you sure?' },
+            class: 'flex-1 bg-red-500 hover:bg-red-600 text-white px-3 py-2 rounded text-center text-sm font-medium transition-colors' %>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/offerings/index.html.erb
+++ b/app/views/offerings/index.html.erb
@@ -1,45 +1,21 @@
-<div class="container mx-auto p-4">
-  <div class="max-w-4xl mx-auto">
+<div class="min-h-screen bg-gray-50 dark:bg-gray-900 py-8">
+  <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="flex justify-between items-center mb-6">
-      <h1 class="text-3xl font-bold">My Offerings</h1>
-      <%= link_to "Create New Offering", new_offering_path, 
+      <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100">My Offerings</h1>
+      <%= link_to "Create New Offering", new_offering_path,
           class: "bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-colors" %>
     </div>
 
     <% if @offerings.any? %>
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        <% @offerings.each do |offering| %>
-          <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg overflow-hidden hover:shadow-lg transition-shadow">
-            <div class="p-6">
-              <h3 class="text-xl font-semibold mb-2"><%= offering.title %></h3>
-              <p class="text-gray-600 dark:text-gray-300 mb-4 line-clamp-3"><%= truncate(offering.description, length: 100) %></p>
-              
-              <div class="flex justify-between items-center mb-4">
-                <span class="text-2xl font-bold text-green-600">$<%= offering.price %></span>
-                <span class="bg-gray-100 dark:bg-gray-800 text-gray-800 dark:text-gray-100 text-sm px-2 py-1 rounded-full">
-                  📍 <%= offering.location %>
-                </span>
-              </div>
-
-              <div class="flex space-x-2">
-                <%= link_to "View", offering, 
-                    class: "flex-1 bg-blue-500 hover:bg-blue-600 text-white px-3 py-2 rounded text-center text-sm font-medium transition-colors" %>
-                <%= link_to "Edit", edit_offering_path(offering), 
-                    class: "flex-1 bg-gray-500 dark:bg-gray-700 hover:bg-gray-600 text-white px-3 py-2 rounded text-center text-sm font-medium transition-colors" %>
-                <%= link_to "Delete", offering, method: :delete, 
-                    data: { confirm: "Are you sure?" },
-                    class: "flex-1 bg-red-500 hover:bg-red-600 text-white px-3 py-2 rounded text-center text-sm font-medium transition-colors" %>
-              </div>
-            </div>
-          </div>
-        <% end %>
+        <%= render partial: "offerings/card", collection: @offerings, as: :offering, locals: { show_actions: true } %>
       </div>
     <% else %>
       <div class="text-center py-12">
         <div class="text-gray-400 text-6xl mb-4">🏠</div>
         <h2 class="text-2xl font-semibold text-gray-600 dark:text-gray-300 mb-2">No offerings yet</h2>
         <p class="text-gray-500 dark:text-gray-400 mb-6">Start sharing your local expertise with travelers!</p>
-        <%= link_to "Create Your First Offering", new_offering_path, 
+        <%= link_to "Create Your First Offering", new_offering_path,
             class: "bg-blue-500 hover:bg-blue-600 text-white px-6 py-3 rounded-md font-medium transition-colors" %>
       </div>
     <% end %>

--- a/app/views/offerings/show.html.erb
+++ b/app/views/offerings/show.html.erb
@@ -1,10 +1,10 @@
-<div class="container mx-auto p-4">
-  <div class="max-w-4xl mx-auto">
-    <div class="bg-white dark:bg-gray-800 shadow-lg rounded-lg overflow-hidden">
-      <div class="p-8">
+<div class="min-h-screen bg-gray-50 dark:bg-gray-900 py-8">
+  <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md overflow-hidden">
+      <div class="p-6">
         <div class="flex justify-between items-start mb-6">
           <div>
-            <h1 class="text-3xl font-bold mb-2"><%= @offering.title %></h1>
+            <h1 class="text-3xl font-bold mb-2 text-gray-900 dark:text-gray-100"><%= @offering.title %></h1>
             <div class="flex items-center space-x-4 text-gray-600 dark:text-gray-300">
               <span class="flex items-center">
                 📍 <%= @offering.location %>
@@ -21,18 +21,18 @@
         </div>
 
         <div class="mb-8">
-          <h2 class="text-xl font-semibold mb-4">About this experience</h2>
+          <h2 class="text-xl font-semibold mb-4 text-gray-900 dark:text-gray-100">About this experience</h2>
           <p class="text-gray-700 dark:text-gray-200 leading-relaxed"><%= simple_format(@offering.description) %></p>
         </div>
 
         <div class="mb-8">
-          <h2 class="text-xl font-semibold mb-4">About your host</h2>
+          <h2 class="text-xl font-semibold mb-4 text-gray-900 dark:text-gray-100">About your host</h2>
           <div class="flex items-start space-x-4">
             <div class="w-16 h-16 bg-blue-500 rounded-full flex items-center justify-center text-white font-bold text-2xl">
               <%= @offering.user.initials %>
             </div>
             <div>
-              <h3 class="text-lg font-semibold"><%= @offering.user.display_name %></h3>
+              <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100"><%= @offering.user.display_name %></h3>
               <p class="text-sm text-gray-500 dark:text-gray-400">@<%= @offering.user.username %></p>
               <div class="mt-2">
                 <h4 class="text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">Locations:</h4>
@@ -57,27 +57,19 @@
         </div>
 
         <div class="mb-8">
-          <h2 class="text-xl font-semibold mb-4">Reviews</h2>
-          <% @reviews.each do |review| %>
-            <div class="mb-4">
-              <div class="font-semibold"><%= review.user.display_name %></div>
-              <div class="text-yellow-500">Rating: <%= review.rating %>/5</div>
-              <p class="text-gray-700 dark:text-gray-200"><%= review.comment %></p>
-              <% if review.user == current_user %>
-                <%= link_to 'Delete', offering_review_path(@offering, review), method: :delete,
-                    data: { confirm: 'Are you sure?' }, class: 'text-red-500 text-sm' %>
-              <% end %>
-            </div>
-          <% end %>
+          <h2 class="text-xl font-semibold mb-4 text-gray-900 dark:text-gray-100">Reviews</h2>
+          <div class="space-y-4">
+            <%= render partial: 'reviews/review', collection: @reviews, as: :review, locals: { offering: @offering } %>
+          </div>
           <% if @can_review %>
             <%= form_with model: [@offering, @review], local: true do |f| %>
               <div class="mb-2">
-                <%= f.label :rating %>
-                <%= f.number_field :rating, in: 1..5 %>
+                <%= f.label :rating, class: 'block text-sm font-medium text-gray-700 dark:text-gray-200' %>
+                <%= f.number_field :rating, in: 1..5, class: 'mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700' %>
               </div>
               <div class="mb-2">
-                <%= f.label :comment %>
-                <%= f.text_area :comment %>
+                <%= f.label :comment, class: 'block text-sm font-medium text-gray-700 dark:text-gray-200' %>
+                <%= f.text_area :comment, rows: 3, class: 'mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700' %>
               </div>
               <%= f.submit 'Submit Review', class: 'bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md' %>
             <% end %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -180,14 +180,7 @@
           <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">Hosted Offerings</h2>
           <% if @offerings.any? %>
             <div class="space-y-4">
-              <% @offerings.each do |offering| %>
-                <div class="border border-gray-200 dark:border-gray-700 rounded-lg p-4">
-                  <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
-                    <%= link_to offering.title, offering_path(offering), class: "hover:text-blue-600" %>
-                  </h3>
-                  <p class="text-sm text-gray-500 dark:text-gray-400"><%= offering.location.titleize %></p>
-                </div>
-              <% end %>
+              <%= render partial: 'offerings/card', collection: @offerings, as: :offering, locals: { compact: true } %>
             </div>
           <% else %>
             <p class="text-sm text-gray-500 dark:text-gray-400">No offerings yet.</p>
@@ -200,15 +193,7 @@
           <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">Reviews</h2>
           <% if @user.reviews.any? %>
             <div class="space-y-4">
-              <% @user.reviews.each do |review| %>
-                <div class="border border-gray-200 dark:border-gray-700 rounded-lg p-4">
-                  <div class="flex items-center justify-between mb-2">
-                    <span class="font-medium text-gray-900 dark:text-gray-100"><%= review.user.display_name %></span>
-                    <span class="text-yellow-500">⭐️ <%= review.rating %></span>
-                  </div>
-                  <p class="text-gray-700 dark:text-gray-300 text-sm"><%= review.comment %></p>
-                </div>
-              <% end %>
+              <%= render partial: 'reviews/review', collection: @user.reviews, as: :review %>
             </div>
           <% else %>
             <p class="text-sm text-gray-500 dark:text-gray-400">No reviews yet.</p>

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -1,6 +1,6 @@
-<div class="container mx-auto p-4">
+<div class="min-h-screen bg-gray-50 dark:bg-gray-900 py-8">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-    <h1 class="text-3xl font-bold mb-4 text-center">Local Hosts & Guides</h1>
+    <h1 class="text-3xl font-bold mb-4 text-center text-gray-900 dark:text-gray-100">Local Hosts & Guides</h1>
 
     <%= form_with url: search_results_path, method: :get, class: "mb-6", data: { turbo_frame: "search_results", controller: "search-tags" } do |f| %>
       <input type="hidden" name="tags" value="<%= Array(@search_tags).join(',') %>" data-search-tags-target="hidden">
@@ -13,13 +13,13 @@
         <% if @profiles.present? %>
           <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             <% @profiles.each do |profile| %>
-              <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-6 hover:shadow-lg transition-shadow">
+              <%= render 'shared/card', classes: 'hover:shadow-lg transition-shadow', content: capture do %>
                 <div class="flex items-center mb-4">
                   <div class="w-12 h-12 bg-blue-500 rounded-full flex items-center justify-center text-white font-bold text-xl">
                     <%= profile.initials %>
                   </div>
                   <div class="ml-3">
-                    <h2 class="text-xl font-semibold"><%= profile.display_name %></h2>
+                    <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100"><%= profile.display_name %></h2>
                     <p class="text-gray-500 dark:text-gray-400 text-sm">@<%= profile.username %> • Local Host</p>
                   </div>
                 </div>
@@ -39,33 +39,23 @@
                   <%= link_to "View Profile", user_path(profile),
                       class: "bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md text-sm font-medium transition-colors" %>
                 </div>
-              </div>
+              <% end %>
             <% end %>
           </div>
         <% end %>
 
         <% if @offerings.present? %>
-          <h2 class="text-2xl font-bold mt-10 mb-4">Offerings</h2>
-          <ul class="space-y-4">
-            <% @offerings.each do |offering| %>
-              <li class="p-4 bg-white dark:bg-gray-800 shadow rounded">
-                <h3 class="text-lg font-semibold"><%= offering.title %></h3>
-                <p class="text-sm text-gray-500 dark:text-gray-400"><%= offering.location %></p>
-              </li>
-            <% end %>
-          </ul>
+          <h2 class="text-2xl font-bold mt-10 mb-4 text-gray-900 dark:text-gray-100">Offerings</h2>
+          <div class="space-y-4">
+            <%= render partial: 'offerings/card', collection: @offerings, as: :offering, locals: { compact: true } %>
+          </div>
         <% end %>
 
         <% if @reviews.present? %>
-          <h2 class="text-2xl font-bold mt-10 mb-4">Reviews</h2>
-          <ul class="space-y-4">
-            <% @reviews.each do |review| %>
-              <li class="p-4 bg-white dark:bg-gray-800 shadow rounded">
-                <p class="mb-2"><%= review.comment %></p>
-                <p class="text-sm text-gray-500 dark:text-gray-400">Rating: <%= review.rating %></p>
-              </li>
-            <% end %>
-          </ul>
+          <h2 class="text-2xl font-bold mt-10 mb-4 text-gray-900 dark:text-gray-100">Reviews</h2>
+          <div class="space-y-4">
+            <%= render partial: 'reviews/review', collection: @reviews, as: :review %>
+          </div>
         <% end %>
 
           <% unless @profiles.present? || @offerings.present? || @reviews.present? %>

--- a/app/views/reviews/_review.html.erb
+++ b/app/views/reviews/_review.html.erb
@@ -1,0 +1,11 @@
+<%= render 'shared/card', content: capture do %>
+  <div class="flex items-center justify-between mb-2">
+    <span class="font-semibold text-gray-900 dark:text-gray-100"><%= review.user.display_name %></span>
+    <span class="text-yellow-500 text-sm">⭐️ <%= review.rating %></span>
+  </div>
+  <p class="text-gray-700 dark:text-gray-300 text-sm mb-2"><%= review.comment %></p>
+  <% if defined?(offering) && offering && review.user == current_user %>
+    <%= link_to 'Delete', offering_review_path(offering, review), method: :delete,
+        data: { confirm: 'Are you sure?' }, class: 'text-red-500 text-xs' %>
+  <% end %>
+<% end %>

--- a/app/views/shared/_card.html.erb
+++ b/app/views/shared/_card.html.erb
@@ -1,0 +1,5 @@
+<% classes = local_assigns.fetch(:classes, '') %>
+<% content = local_assigns.fetch(:content, '') %>
+<div class="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6 <%= classes %>">
+  <%= content %>
+</div>


### PR DESCRIPTION
## Summary
- Introduce reusable card partials for offerings and reviews using shared Tailwind container
- Align offerings and results pages with booking layout spacing, typography, and dark-mode defaults
- Replace duplicated review and offering markup with extracted partials

## Testing
- `bundle exec rspec` *(fails: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed)*

------
https://chatgpt.com/codex/tasks/task_b_68b9dcffd40483308cd36cf8046c9a3f