### PR TITLE
Refactor profile show into partials with hero header and card layout

### DIFF
--- a/app/views/components/_card.html.erb
+++ b/app/views/components/_card.html.erb
@@ -1,0 +1,5 @@
+<% classes = "bg-white dark:bg-gray-800 shadow rounded-lg p-6" %>
+<% classes = "#{classes} #{local_assigns[:class]}" if local_assigns[:class] %>
+<%= content_tag :div, class: classes, data: local_assigns[:data] do %>
+  <%= yield %>
+<% end %>

--- a/app/views/profiles/_bio_form.html.erb
+++ b/app/views/profiles/_bio_form.html.erb
@@ -1,0 +1,32 @@
+<%= render 'components/card' do %>
+  <% if is_own_profile %>
+    <%= form_with model: user, url: profile_path, method: :patch, local: true do |f| %>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div>
+          <%= f.label :country, "Country", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
+          <%= f.select :country, options_for_select(Carmen::Country.all.map { |c| [c.name, c.alpha_2_code] }, user.try(:country)), { include_blank: 'Select your country' }, { class: "mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700" } %>
+        </div>
+        <div>
+          <%= f.label :languages, "Languages spoken", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
+          <%= f.text_field :languages, class: "mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700" %>
+        </div>
+        <div>
+          <%= f.label :hosting_available, "Available to host?", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
+          <%= f.select :hosting_available, [["Yes", true], ["No", false]], {}, { class: "mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700" } %>
+        </div>
+        <div class="sm:col-span-2">
+          <%= f.label :bio, class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
+          <%= f.text_area :bio, rows: 4, class: "mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700" %>
+        </div>
+        <div class="sm:col-span-2">
+          <%= f.submit "Update Profile", class: "mt-2 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700" %>
+        </div>
+      </div>
+    <% end %>
+  <% else %>
+    <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">About</h2>
+    <p class="text-gray-700 dark:text-gray-300 mb-4"><%= user.bio.presence || 'No bio yet.' %></p>
+    <p class="text-sm text-gray-500 dark:text-gray-400"><strong>Languages:</strong> <%= user.languages.presence || 'Not specified' %></p>
+    <p class="text-sm text-gray-500 dark:text-gray-400 mt-1"><strong>Hosting:</strong> <%= user.hosting_available? ? 'Available to host' : 'Not available to host' %></p>
+  <% end %>
+<% end %>

--- a/app/views/profiles/_gallery.html.erb
+++ b/app/views/profiles/_gallery.html.erb
@@ -1,19 +1,19 @@
-<% if user.photos.attached? %>
-  <div class="grid grid-cols-2 sm:grid-cols-3 gap-4">
-    <% user.photos.each do |photo| %>
-      <div class="relative group">
-        <%= image_tag photo.variant(resize_to_fill: [300, 200]), class: "rounded-lg object-cover w-full h-48" %>
-        <% if is_own_profile %>
-          <button type="button"
-                  data-action="click->gallery#removeExisting"
-                  data-url="<%= remove_photo_profile_path(photo_id: photo.id) %>"
-                  class="absolute top-2 right-2 bg-red-600 text-white text-xs rounded px-2 py-1 opacity-0 group-hover:opacity-100">
-            Delete
-          </button>
-        <% end %>
+<%= render 'components/card', data: { controller: 'gallery' } do %>
+  <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">Photos</h2>
+
+  <% if is_own_profile %>
+    <%= form_with model: user, url: add_photo_profile_path, method: :post, local: true, html: { multipart: true, data: { gallery_target: "form" } }, class: "mb-4" do |f| %>
+      <div class="flex flex-col gap-2">
+        <div class="flex items-center gap-2">
+          <%= f.file_field :photos, multiple: true, class: "flex-1 rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700", data: { action: "change->gallery#preview", gallery_target: "input" } %>
+          <%= f.submit "Upload", class: "px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700" %>
+        </div>
+        <div data-gallery-target="previews" class="flex flex-wrap gap-2"></div>
       </div>
     <% end %>
+  <% end %>
+
+  <div data-gallery-target="gallery">
+    <%= render partial: 'profiles/gallery_grid', locals: { user: user, is_own_profile: is_own_profile } %>
   </div>
-<% else %>
-  <p class="text-sm text-gray-500 dark:text-gray-400">No photos yet.</p>
 <% end %>

--- a/app/views/profiles/_gallery_grid.html.erb
+++ b/app/views/profiles/_gallery_grid.html.erb
@@ -1,0 +1,19 @@
+<% if user.photos.attached? %>
+  <div class="grid grid-cols-2 sm:grid-cols-3 gap-4">
+    <% user.photos.each do |photo| %>
+      <div class="relative group">
+        <%= image_tag photo.variant(resize_to_fill: [300, 200]), class: "rounded-lg object-cover w-full h-48" %>
+        <% if is_own_profile %>
+          <button type="button"
+                  data-action="click->gallery#removeExisting"
+                  data-url="<%= remove_photo_profile_path(photo_id: photo.id) %>"
+                  class="absolute top-2 right-2 bg-red-600 text-white text-xs rounded px-2 py-1 opacity-0 group-hover:opacity-100">
+            Delete
+          </button>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+<% else %>
+  <p class="text-sm text-gray-500 dark:text-gray-400">No photos yet.</p>
+<% end %>

--- a/app/views/profiles/_header.html.erb
+++ b/app/views/profiles/_header.html.erb
@@ -1,0 +1,43 @@
+<%= render 'components/card', class: 'overflow-hidden' do %>
+  <div class="relative">
+    <% if user.respond_to?(:cover_image) && user.cover_image.attached? %>
+      <%= image_tag user.cover_image, class: "w-full h-48 object-cover" %>
+    <% else %>
+      <div class="w-full h-48 bg-gray-200 dark:bg-gray-700"></div>
+    <% end %>
+    <div class="absolute left-1/2 bottom-0 transform -translate-x-1/2 translate-y-1/2">
+      <div class="relative">
+        <% if user.profile_picture.attached? %>
+          <%= image_tag user.profile_picture.variant(resize_to_fill: [128, 128]), class: "w-32 h-32 rounded-full object-cover border-4 border-white dark:border-gray-800" %>
+        <% else %>
+          <div class="w-32 h-32 rounded-full bg-blue-500 text-white flex items-center justify-center text-3xl font-bold border-4 border-white dark:border-gray-800">
+            <%= user.initials %>
+          </div>
+        <% end %>
+        <% if is_own_profile %>
+          <%= form_with model: user, url: update_picture_profile_path, method: :patch, local: true, html: { multipart: true }, class: "absolute inset-0 rounded-full overflow-hidden flex items-center justify-center opacity-0 hover:opacity-100 transition-opacity bg-black bg-opacity-60" do |f| %>
+            <%= f.file_field :profile_picture, class: "absolute inset-0 opacity-0 cursor-pointer" %>
+            <span class="text-white text-sm">Change</span>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+  <div class="pt-16 pb-6 text-center px-6">
+    <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100"><%= user.display_name %></h1>
+    <p class="text-gray-500 dark:text-gray-400">@<%= user.username %></p>
+    <% if user.try(:country).present? %>
+      <p class="text-gray-500 dark:text-gray-400 mt-1"><%= Carmen::Country.coded(user.country).name %></p>
+    <% end %>
+    <div class="flex justify-center space-x-6 mt-4">
+      <div class="text-center">
+        <p class="text-lg font-semibold text-gray-900 dark:text-gray-100"><%= user.followers.count %></p>
+        <p class="text-sm text-gray-500 dark:text-gray-400">Followers</p>
+      </div>
+      <div class="text-center">
+        <p class="text-lg font-semibold text-gray-900 dark:text-gray-100"><%= user.following.count %></p>
+        <p class="text-sm text-gray-500 dark:text-gray-400">Following</p>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/profiles/_offerings.html.erb
+++ b/app/views/profiles/_offerings.html.erb
@@ -1,0 +1,10 @@
+<%= render 'components/card' do %>
+  <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">Hosted Offerings</h2>
+  <% if offerings.any? %>
+    <div class="space-y-4">
+      <%= render partial: 'offerings/card', collection: offerings, as: :offering, locals: { compact: true } %>
+    </div>
+  <% else %>
+    <p class="text-sm text-gray-500 dark:text-gray-400">No offerings yet.</p>
+  <% end %>
+<% end %>

--- a/app/views/profiles/_reviews.html.erb
+++ b/app/views/profiles/_reviews.html.erb
@@ -1,0 +1,10 @@
+<%= render 'components/card' do %>
+  <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">Reviews</h2>
+  <% if reviews.any? %>
+    <div class="space-y-4">
+      <%= render partial: 'reviews/review', collection: reviews, as: :review %>
+    </div>
+  <% else %>
+    <p class="text-sm text-gray-500 dark:text-gray-400">No reviews yet.</p>
+  <% end %>
+<% end %>

--- a/app/views/profiles/_tags.html.erb
+++ b/app/views/profiles/_tags.html.erb
@@ -1,0 +1,63 @@
+<%= render 'components/card' do %>
+  <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">Interests & Tags</h2>
+  <div class="space-y-4">
+    <div>
+      <h3 class="font-medium text-gray-900 dark:text-gray-100 mb-2">Interests</h3>
+      <div class="flex flex-wrap gap-2">
+        <% if user.tags.any? %>
+          <% user.tags.each do |tag| %>
+            <span class="px-3 py-1 bg-gray-200 dark:bg-gray-700 rounded-full text-sm text-gray-800 dark:text-gray-200">
+              <%= tag.name %>
+              <% if is_own_profile %>
+                <%= link_to "×", remove_tag_profile_path(tag_type: 'interest', tag_id: tag.id), method: :delete, class: "ml-1 text-gray-500 hover:text-red-500" %>
+              <% end %>
+            </span>
+          <% end %>
+        <% else %>
+          <p class="text-sm text-gray-500 dark:text-gray-400">No interests added yet.</p>
+        <% end %>
+      </div>
+    </div>
+    <div>
+      <h3 class="font-medium text-gray-900 dark:text-gray-100 mb-2">Locations</h3>
+      <div class="flex flex-wrap gap-2">
+        <% if location_tags.any? %>
+          <% location_tags.each do |tag| %>
+            <span class="px-3 py-1 bg-gray-200 dark:bg-gray-700 rounded-full text-sm text-gray-800 dark:text-gray-200">
+              <%= tag.location %>
+              <% if is_own_profile %>
+                <%= link_to "×", remove_tag_profile_path(tag_type: 'location', tag_id: tag.id), method: :delete, class: "ml-1 text-gray-500 hover:text-red-500" %>
+              <% end %>
+            </span>
+          <% end %>
+        <% else %>
+          <p class="text-sm text-gray-500 dark:text-gray-400">No location tags.</p>
+        <% end %>
+      </div>
+    </div>
+    <div>
+      <h3 class="font-medium text-gray-900 dark:text-gray-100 mb-2">Professions</h3>
+      <div class="flex flex-wrap gap-2">
+        <% if profession_tags.any? %>
+          <% profession_tags.each do |tag| %>
+            <span class="px-3 py-1 bg-gray-200 dark:bg-gray-700 rounded-full text-sm text-gray-800 dark:text-gray-200">
+              <%= tag.profession %>
+              <% if is_own_profile %>
+                <%= link_to "×", remove_tag_profile_path(tag_type: 'profession', tag_id: tag.id), method: :delete, class: "ml-1 text-gray-500 hover:text-red-500" %>
+              <% end %>
+            </span>
+          <% end %>
+        <% else %>
+          <p class="text-sm text-gray-500 dark:text-gray-400">No profession tags.</p>
+        <% end %>
+      </div>
+    </div>
+  </div>
+  <% if is_own_profile %>
+    <%= form_with url: add_tag_profile_path, method: :post, local: true, class: "mt-6 flex flex-col sm:flex-row gap-2" do |f| %>
+      <%= f.text_field :tag_name, placeholder: "Add a tag", class: "flex-1 rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700" %>
+      <%= f.select :tag_type, [["Interest", "interest"], ["Location", "location"], ["Profession", "profession"]], {}, class: "rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700" %>
+      <%= f.submit "Add", class: "px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700" %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -12,195 +12,27 @@
         <%= render 'sidebar' %>
       </aside>
       <div class="flex-1 space-y-6">
-      <section id="bio-info" data-profile-navigation-target="section" class="space-y-6">
-        <!-- Profile Header -->
-        <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6 flex flex-col sm:flex-row sm:items-center gap-6">
-          <div class="relative">
-            <% if @user.profile_picture.attached? %>
-              <%= image_tag @user.profile_picture.variant(resize_to_fill: [128,128]), class: "w-32 h-32 rounded-full object-cover" %>
-            <% else %>
-              <div class="w-32 h-32 rounded-full bg-blue-500 text-white flex items-center justify-center text-3xl font-bold">
-                <%= @user.initials %>
-              </div>
-            <% end %>
-            <% if @is_own_profile %>
-              <%= form_with model: @user, url: update_picture_profile_path, method: :patch, local: true, html: { multipart: true }, class: "absolute inset-0 rounded-full overflow-hidden flex items-center justify-center opacity-0 hover:opacity-100 transition-opacity bg-black bg-opacity-60" do |f| %>
-                <%= f.file_field :profile_picture, class: "absolute inset-0 opacity-0 cursor-pointer" %>
-                <span class="text-white text-sm">Change</span>
-              <% end %>
-            <% end %>
-          </div>
-          <div class="flex-1">
-            <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100"><%= @user.display_name %></h1>
-            <p class="text-gray-500 dark:text-gray-400">@<%= @user.username %></p>
-            <% if @user.try(:country).present? %>
-              <p class="text-gray-500 dark:text-gray-400 mt-1"><%= Carmen::Country.coded(@user.country).name %></p>
-            <% end %>
-            <div class="flex space-x-6 mt-4">
-              <div class="text-center">
-                <p class="text-lg font-semibold text-gray-900 dark:text-gray-100"><%= @user.followers.count %></p>
-                <p class="text-sm text-gray-500 dark:text-gray-400">Followers</p>
-              </div>
-              <div class="text-center">
-                <p class="text-lg font-semibold text-gray-900 dark:text-gray-100"><%= @user.following.count %></p>
-                <p class="text-sm text-gray-500 dark:text-gray-400">Following</p>
-              </div>
-            </div>
-          </div>
-        </div>
+        <section id="bio-info" data-profile-navigation-target="section" class="space-y-6">
+          <%= render 'profiles/header', user: @user, is_own_profile: @is_own_profile %>
+          <%= render 'profiles/bio_form', user: @user, is_own_profile: @is_own_profile %>
+        </section>
 
-        <!-- Profile Info -->
-        <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
-          <% if @is_own_profile %>
-            <%= form_with model: @user, url: profile_path, method: :patch, local: true do |f| %>
-              <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <div>
-                  <%= f.label :country, "Country", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
-                  <%= f.select :country,
-                        options_for_select(Carmen::Country.all.map { |c| [c.name, c.alpha_2_code] }, @user.try(:country)),
-                        { include_blank: 'Select your country' },
-                        { class: "mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700" } %>
-                </div>
-                <div>
-                  <%= f.label :languages, "Languages spoken", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
-                  <%= f.text_field :languages, class: "mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700" %>
-                </div>
-                <div>
-                  <%= f.label :hosting_available, "Available to host?", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
-                  <%= f.select :hosting_available, [["Yes", true], ["No", false]], {}, { class: "mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700" } %>
-                </div>
-                <div class="sm:col-span-2">
-                  <%= f.label :bio, class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
-                  <%= f.text_area :bio, rows: 4, class: "mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700" %>
-                </div>
-                <div class="sm:col-span-2">
-                  <%= f.submit "Update Profile", class: "mt-2 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700" %>
-                </div>
-              </div>
-            <% end %>
-          <% else %>
-            <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">About</h2>
-            <p class="text-gray-700 dark:text-gray-300 mb-4"><%= @user.bio.presence || 'No bio yet.' %></p>
-            <p class="text-sm text-gray-500 dark:text-gray-400"><strong>Languages:</strong> <%= @user.languages.presence || 'Not specified' %></p>
-            <p class="text-sm text-gray-500 dark:text-gray-400 mt-1"><strong>Hosting:</strong> <%= @user.hosting_available? ? 'Available to host' : 'Not available to host' %></p>
-          <% end %>
-        </div>
-      </section>
+        <section id="location-interests" data-profile-navigation-target="section">
+          <%= render 'profiles/tags', user: @user, location_tags: @location_tags, profession_tags: @profession_tags, is_own_profile: @is_own_profile %>
+        </section>
 
-      <section id="location-interests" data-profile-navigation-target="section">
-        <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
-          <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">Interests &amp; Tags</h2>
-          <div class="space-y-4">
-            <div>
-              <h3 class="font-medium text-gray-900 dark:text-gray-100 mb-2">Interests</h3>
-              <div class="flex flex-wrap gap-2">
-                <% if @user.tags.any? %>
-                  <% @user.tags.each do |tag| %>
-                    <span class="px-3 py-1 bg-gray-200 dark:bg-gray-700 rounded-full text-sm text-gray-800 dark:text-gray-200">
-                      <%= tag.name %>
-                      <% if @is_own_profile %>
-                        <%= link_to "×", remove_tag_profile_path(tag_type: 'interest', tag_id: tag.id), method: :delete, class: "ml-1 text-gray-500 hover:text-red-500" %>
-                      <% end %>
-                    </span>
-                  <% end %>
-                <% else %>
-                  <p class="text-sm text-gray-500 dark:text-gray-400">No interests added yet.</p>
-                <% end %>
-              </div>
-            </div>
-            <div>
-              <h3 class="font-medium text-gray-900 dark:text-gray-100 mb-2">Locations</h3>
-              <div class="flex flex-wrap gap-2">
-                <% if @location_tags.any? %>
-                  <% @location_tags.each do |tag| %>
-                    <span class="px-3 py-1 bg-gray-200 dark:bg-gray-700 rounded-full text-sm text-gray-800 dark:text-gray-200">
-                      <%= tag.location %>
-                      <% if @is_own_profile %>
-                        <%= link_to "×", remove_tag_profile_path(tag_type: 'location', tag_id: tag.id), method: :delete, class: "ml-1 text-gray-500 hover:text-red-500" %>
-                      <% end %>
-                    </span>
-                  <% end %>
-                <% else %>
-                  <p class="text-sm text-gray-500 dark:text-gray-400">No location tags.</p>
-                <% end %>
-              </div>
-            </div>
-            <div>
-              <h3 class="font-medium text-gray-900 dark:text-gray-100 mb-2">Professions</h3>
-              <div class="flex flex-wrap gap-2">
-                <% if @profession_tags.any? %>
-                  <% @profession_tags.each do |tag| %>
-                    <span class="px-3 py-1 bg-gray-200 dark:bg-gray-700 rounded-full text-sm text-gray-800 dark:text-gray-200">
-                      <%= tag.profession %>
-                      <% if @is_own_profile %>
-                        <%= link_to "×", remove_tag_profile_path(tag_type: 'profession', tag_id: tag.id), method: :delete, class: "ml-1 text-gray-500 hover:text-red-500" %>
-                      <% end %>
-                    </span>
-                  <% end %>
-                <% else %>
-                  <p class="text-sm text-gray-500 dark:text-gray-400">No profession tags.</p>
-                <% end %>
-              </div>
-            </div>
-          </div>
-          <% if @is_own_profile %>
-            <%= form_with url: add_tag_profile_path, method: :post, local: true, class: "mt-6 flex flex-col sm:flex-row gap-2" do |f| %>
-              <%= f.text_field :tag_name, placeholder: "Add a tag", class: "flex-1 rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700" %>
-              <%= f.select :tag_type, [["Interest", "interest"], ["Location", "location"], ["Profession", "profession"]], {}, { class: "rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700" } %>
-              <%= f.submit "Add", class: "px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700" %>
-            <% end %>
-          <% end %>
-        </div>
-      </section>
+        <section id="gallery" data-profile-navigation-target="section">
+          <%= render 'profiles/gallery', user: @user, is_own_profile: @is_own_profile %>
+        </section>
 
-      <section id="gallery" data-profile-navigation-target="section">
-        <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6" data-controller="gallery">
-          <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">Photos</h2>
+        <section id="hosted-offerings" data-profile-navigation-target="section">
+          <%= render 'profiles/offerings', offerings: @offerings %>
+        </section>
 
-          <% if @is_own_profile %>
-            <%= form_with model: @user, url: add_photo_profile_path, method: :post, local: true, html: { multipart: true, data: { gallery_target: "form" } }, class: "mb-4" do |f| %>
-              <div class="flex flex-col gap-2">
-                <div class="flex items-center gap-2">
-                  <%= f.file_field :photos, multiple: true, class: "flex-1 rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700", data: { action: "change->gallery#preview", gallery_target: "input" } %>
-                  <%= f.submit "Upload", class: "px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700" %>
-                </div>
-                <div data-gallery-target="previews" class="flex flex-wrap gap-2"></div>
-              </div>
-            <% end %>
-          <% end %>
-
-          <div data-gallery-target="gallery">
-            <%= render partial: "profiles/gallery", locals: { user: @user, is_own_profile: @is_own_profile } %>
-          </div>
-        </div>
-      </section>
-
-      <section id="hosted-offerings" data-profile-navigation-target="section">
-        <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
-          <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">Hosted Offerings</h2>
-          <% if @offerings.any? %>
-            <div class="space-y-4">
-              <%= render partial: 'offerings/card', collection: @offerings, as: :offering, locals: { compact: true } %>
-            </div>
-          <% else %>
-            <p class="text-sm text-gray-500 dark:text-gray-400">No offerings yet.</p>
-          <% end %>
-        </div>
-      </section>
-
-      <section id="reviews" data-profile-navigation-target="section">
-        <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
-          <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">Reviews</h2>
-          <% if @user.reviews.any? %>
-            <div class="space-y-4">
-              <%= render partial: 'reviews/review', collection: @user.reviews, as: :review %>
-            </div>
-          <% else %>
-            <p class="text-sm text-gray-500 dark:text-gray-400">No reviews yet.</p>
-          <% end %>
-        </div>
-      </section>
+        <section id="reviews" data-profile-navigation-target="section">
+          <%= render 'profiles/reviews', reviews: @user.reviews %>
+        </section>
+      </div>
     </div>
   </div>
 </div>
-


### PR DESCRIPTION
## Summary
- Split profile show page into partials for header, bio form, tags, gallery, offerings, and reviews
- Added hero header with cover image, large avatar, and follower/following stats
- Introduced reusable card component for consistent spacing and shadows

## Testing
- `bundle exec rspec` *(fails: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68b9e6c99d4483309a48b58e654e2b0a